### PR TITLE
Add RealtimePi

### DIFF
--- a/src/distros_list/RealtimePi.json
+++ b/src/distros_list/RealtimePi.json
@@ -1,0 +1,12 @@
+{
+    "path": [],
+    "os_list": [
+        {
+            "name": "RealtimePi",
+            "description": "An out-of-the-box RaspberryPi OS with a realtime kernel",
+            "icon": "https://raw.githubusercontent.com/guysoft/RealtimePi/devel/media/rpi-imager-RealtimePi.png",
+            "website": "https://github.com/guysoft/RealtimePi",
+            "subitems_url": "https://unofficialpi.org/rpi-imager/rpi-imager-realtimepi.json"
+        }
+    ]
+}


### PR DESCRIPTION
RealtimePi is Rpi OS with the realtime kernel installed from https://github.com/kdoren/linux/releases/tag/5.10.35-rt39
Its been running for a while and now it can be added to the imager.

I am also writing this PR so you guys can see how easy it is to propose a new image, upon merging it gets added.