### PR TITLE
Add MtigOS

### DIFF
--- a/src/distros_list/MtigOS.json
+++ b/src/distros_list/MtigOS.json
@@ -1,0 +1,12 @@
+{
+    "path": [],
+    "os_list": [
+        {
+            "name": "MtigOS",
+            "description": "Raspberry Pi distro that lets you receive, store and graph sensor information from ESP8266 chips",
+            "icon": "https://raw.githubusercontent.com/guysoft/CustomPiOS/devel/media/rpi-imager-CustomPiOS.png",
+            "website": "https://github.com/guysoft/MtigOS",
+            "subitems_url": "https://unofficialpi.org/rpi-imager/rpi-imager-mtigos.json"
+        }
+    ]
+}


### PR DESCRIPTION
A Rpi distro that lets you receive, store and graph sensor information from ESP8266 chips.

It uses and MTIG stack: [Mosquitto](https://mosquitto.org/), [Telegraf](https://www.influxdata.com/time-series-platform/telegraf/), [InfluxDB](https://www.influxdata.com/) and [Grafana](https://grafana.com/) which are all pre-configured to work together. They automatically update using Docker.