### PR TITLE
Add HotSpotOS

### DIFF
--- a/src/distros_list/HotSpotOS.json
+++ b/src/distros_list/HotSpotOS.json
@@ -1,0 +1,12 @@
+{
+    "path": [],
+    "os_list": [
+        {
+            "name": "HotSpotOS",
+            "description": "Start a hotspot, bridges internet comming in from ethernet.",
+            "icon": "https://raw.githubusercontent.com/guysoft/HotSpotOS/devel/media/rpi-imager-HotSpotOS.png",
+            "website": "https://github.com/guysoft/HotSpotOS",
+            "subitems_url": "https://unofficialpi.org/rpi-imager/rpi-imager-hotspotos.json"
+        }
+    ]
+}


### PR DESCRIPTION
A [Raspberry Pi](http://www.raspberrypi.org/) distribution that makes a Raspberrypi start a hotspot, if no wifi was found to conenct to. It also bridges internet comming in from ethernet.

The hotspot scripts are based on the [scripts by roboberry](http://www.raspberryconnect.com/network/item/330-raspberry-pi-auto-wifi-hotspot-switch-internet) . And have been improved. They are part of the auto-hotspot module of [CustomPiOS](https://github.com/guysoft/CustomPiOS). HotSpotOS is based on CustomPiOS

https://github.com/guysoft/HotSpotOS