### PR TITLE
Add ElectricSheepPi

### DIFF
--- a/src/distros_list/ElectricSheepPi.json
+++ b/src/distros_list/ElectricSheepPi.json
@@ -1,0 +1,12 @@
+{
+    "path": [],
+    "os_list": [
+        {
+            "name": "ElectricSheepPi",
+            "description": "A Raspberry Pi distribution to to run Electric Sheep, crowdsourced evolving art",
+            "icon": "https://raw.githubusercontent.com/guysoft/HotSpotOS/devel/media/rpi-imager-HotSpotOS.png",
+            "website": "https://electricsheep.org",
+            "subitems_url": "https://unofficialpi.org/rpi-imager/rpi-imager-electricsheeppi.json"
+        }
+    ]
+}


### PR DESCRIPTION
A [Raspberry Pi](http://www.raspberrypi.org/) distribution to to run [Electric Sheep : Crowdsourced Evolving Art](https://electricsheep.org/) out of the box and the scripts necessary to load it at boot. 

Image build sources: https://github.com/guysoft/ElectricSheepPi