### PR TITLE
Add IEMberry

### DIFF
--- a/src/distros_list/IEMberry.json
+++ b/src/distros_list/IEMberry.json
@@ -1,0 +1,12 @@
+{
+  "path": [],
+  "os_list": [
+    {
+      "name": "IEMberry",
+      "description": "A Raspberry Pi distro for Computer Musicians and Sound Artists",
+      "icon": "https://iemberry.iem.at/logos/rpi-imager-iemberry.png",
+      "website": "https://iemberry.iem.at",
+      "subitems_url": "https://iemberry.iem.at/rpi-imager-iemberry.json"
+    }
+  ]
+}


### PR DESCRIPTION
Add IEMberry.
A Raspberry Pi distribution targeted at (academic) Computer Musicians and Sound Artists.

It contains a wide range of computer music tools (DAWs, realtime audio programming languages), and software development tools.

It is used for the courses at the [Institute of Electronic Music and Acoustics (iem)](https://iem.at/) of the [University of Music and Performing Arts, Graz](https://kug.ac.at).

https://iemberry.iem.at/

Image build sources are hosted at https://git.iem.at/iemberry/iemberryOS

New versions typically appear before the beginning of the winter semester in Austria.